### PR TITLE
"Origin" is an HTTP header, not a request parameter

### DIFF
--- a/server_src/modules/handlers/Home_Core.py
+++ b/server_src/modules/handlers/Home_Core.py
@@ -272,10 +272,10 @@ class Home_Core(object):
 		return self.IsJsonFormat() or self.IsGraphFormat() or self.IsCSVFormat() or self.IsTSVFormat()
 	
 	def HasAllowedOrigin( self ):
-		return 'origin' in self.request.vars
+		return 'HTTP_ORIGIN' in self.request.env
 	
 	def GetAllowedOrigin( self ):
-		return self.request.vars['origin']
+		return self.request.env.HTTP_ORIGIN
 	
 	def GenerateResponse( self ):
 		if self.IsDebugMode():


### PR DESCRIPTION
As noted in https://github.com/uwdata/termite-visualizations/issues/5, the Termite visualization server currently cannot connect to the Termite data server because CORS has not been properly implemented. This fixes that.
